### PR TITLE
refactor: don't lose server state and avoid client echo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
 use async_std::channel::{unbounded, Receiver, Sender};
-use async_std::sync::{Arc, Mutex};
-
 use async_std::net::{SocketAddr, TcpListener, TcpStream};
 use async_tungstenite::{
     accept_async,
@@ -11,20 +9,17 @@ use futures::{prelude::*, stream::SplitSink};
 use log::*;
 use tungstenite::Message;
 
+enum NewNotification {
+    NewClient((SocketAddr, SplitSink<WebSocketStream<TcpStream>, Message>)),
+    NewMessage((SocketAddr, String)),
+}
+
 async fn accept_connection(
     peer: SocketAddr,
     stream: TcpStream,
-    new_server_request_data_tx: Sender<String>,
-    web_socket_shared_container: Arc<Mutex<WebSocketSharedContainer>>,
+    new_server_request_data_tx: Sender<NewNotification>,
 ) {
-    if let Err(e) = handle_connection(
-        peer,
-        stream,
-        new_server_request_data_tx,
-        web_socket_shared_container,
-    )
-    .await
-    {
+    if let Err(e) = handle_connection(peer, stream, new_server_request_data_tx).await {
         match e {
             Error::ConnectionClosed | Error::Protocol(_) | Error::Utf8 => (),
             err => error!("Error processing connection: {}", err),
@@ -35,22 +30,24 @@ async fn accept_connection(
 async fn handle_connection(
     peer: SocketAddr,
     stream: TcpStream,
-    new_server_request_data_tx: Sender<String>,
-    web_socket_shared_container: Arc<Mutex<WebSocketSharedContainer>>,
+    new_server_request_data_tx: Sender<NewNotification>,
 ) -> Result<()> {
     let ws_stream = accept_async(stream).await.expect("Failed to accept");
-    let (mut sender, mut receiver) = ws_stream.split();
-    web_socket_shared_container
-        .lock()
+    let (sender, mut receiver) = ws_stream.split();
+    new_server_request_data_tx
+        .send(NewNotification::NewClient((peer, sender)))
         .await
-        .web_socket_shared_container(sender);
+        .expect("to be able to send to the channel");
 
     info!("New WebSocket connection: {}", peer);
     while let Some(msg) = receiver.next().await {
         let msg = msg?;
         if msg.is_text() || msg.is_binary() {
             // let response = sender.send(Message::Text(msg.to_string())).await;
-            new_server_request_data_tx.send(msg.to_string()).await;
+            new_server_request_data_tx
+                .send(NewNotification::NewMessage((peer, msg.to_string())))
+                .await
+                .expect("to be able to send to the channel ");
         }
     }
 
@@ -59,21 +56,13 @@ async fn handle_connection(
 
 async fn run() {
     env_logger::init();
-    let web_socket_shared_container = Arc::new(Mutex::new(WebSocketSharedContainer {
-        web_socket_stream: None,
-    }));
-
-    let (new_server_request_data_tx, new_server_request_data_rx) = unbounded::<String>();
+    let (new_server_notification_tx, new_server_notification_rx) = unbounded::<NewNotification>();
 
     let addr = "127.0.0.1:8080";
     let listener = TcpListener::bind(&addr).await.expect("Can't listen");
     info!("Listening on: {}", addr);
 
-    let new_server_request_data_rx_arc = Arc::new(Mutex::new(new_server_request_data_rx));
-    async_std::task::spawn(listen_new_messages(
-        Arc::clone(&new_server_request_data_rx_arc),
-        Arc::clone(&web_socket_shared_container),
-    ));
+    async_std::task::spawn(listen_new_messages(new_server_notification_rx));
 
     while let Ok((stream, _)) = listener.accept().await {
         let peer = stream
@@ -84,45 +73,32 @@ async fn run() {
         async_std::task::spawn(accept_connection(
             peer,
             stream,
-            new_server_request_data_tx.clone(),
-            Arc::clone(&web_socket_shared_container),
+            new_server_notification_tx.clone(),
         ));
     }
 }
 
-async fn listen_new_messages(
-    new_server_request_data_rx_arc: Arc<Mutex<Receiver<String>>>,
-    web_socket_shared_container: Arc<Mutex<WebSocketSharedContainer>>,
-) {
+async fn listen_new_messages(new_server_request_data_rx: Receiver<NewNotification>) {
+    let mut connected_clients: Vec<(SocketAddr, SplitSink<WebSocketStream<TcpStream>, Message>)> =
+        vec![];
     loop {
-        let locked = new_server_request_data_rx_arc.lock().await;
-        if let Ok(result) = locked.recv().await {
-            let mut locked_muy = web_socket_shared_container.lock().await;
-            locked_muy.send_message(result).await;
+        if let Ok(result) = new_server_request_data_rx.recv().await {
+            match result {
+                NewNotification::NewClient(new_client) => connected_clients.push(new_client),
+                NewNotification::NewMessage((peer, new_msg)) => {
+                    for (current_client_peer, client_write_stream) in &mut connected_clients {
+                        if &peer != current_client_peer {
+                            client_write_stream
+                                .send(tungstenite::Message::Text(new_msg.clone()))
+                                .await
+                                .expect("to be able to send a message")
+                        }
+                    }
+                }
+            }
         }
     }
 }
 fn main() {
     async_std::task::block_on(run());
-}
-
-struct WebSocketSharedContainer {
-    pub web_socket_stream: Option<SplitSink<WebSocketStream<TcpStream>, Message>>,
-}
-
-impl WebSocketSharedContainer {
-    pub fn web_socket_shared_container(
-        &mut self,
-        websocket: SplitSink<WebSocketStream<TcpStream>, Message>,
-    ) {
-        self.web_socket_stream = Some(websocket);
-    }
-    pub async fn send_message(&mut self, message: String) {
-        let _ = self
-            .web_socket_stream
-            .as_mut()
-            .unwrap()
-            .send(tungstenite::Message::Text(message))
-            .await;
-    }
 }


### PR DESCRIPTION
This PR:
- server was losing clients' sockets on each new connection due to the shared `WebSocketSharedContainer` instance.
- avoid echoing a message to the sender of the message 
- avoid runtime interior mutability 

_I follow u on tw and saw your tweet about you learning Rust and just want to give you a hand :)_
